### PR TITLE
Update transactions stream to remove incremental replication

### DIFF
--- a/tap_braintree/client.py
+++ b/tap_braintree/client.py
@@ -35,6 +35,8 @@ class BraintreeStream(Stream):
     def start_date(self):
         if self.name == 'subscriptions':
             return str(datetime.now() - relativedelta(years=2))
+        elif self.name == 'transactions':
+            return str(datetime.now() - relativedelta(months=1))
         else:
             return self.config["start_date"]
     

--- a/tap_braintree/streams.py
+++ b/tap_braintree/streams.py
@@ -19,8 +19,7 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 class TransactionsStream(BraintreeStream):
     name = "transactions"
     primary_keys = ["id"]
-    replication_method = "INCREMENTAL"
-    replication_key = "updated_at"
+    replication_key = None
 
     braintree_obj = braintree.Transaction
     braintree_search = braintree.TransactionSearch.created_at


### PR DESCRIPTION
Because the Braintree API doesn't actually support incremental replication for the Transactions endpoint, instead of using a broken method of incremental replication, now we will simply ingest the last month's worth of transactions.