### PR TITLE
improve subscription sync with transaction lookahead

### DIFF
--- a/tap_braintree/streams.py
+++ b/tap_braintree/streams.py
@@ -16,6 +16,9 @@ from singer_sdk.typing import (
 import time
 from datetime import datetime, timedelta, date
 from pathlib import Path
+import pytz
+from dateutil.relativedelta import relativedelta
+from dateutil.parser import isoparse
 
 import braintree
 from tap_braintree.client import BraintreeStream
@@ -574,6 +577,124 @@ class SubscriptionsStream(BraintreeStream):
         Property("trial_period", BooleanType),
         Property("updated_at", DateTimeType),
     ).to_dict()
+
+    def get_records(self, context: Optional[dict]) -> Iterable[dict]:
+        """Return a generator of row-type dictionary objects."""
+        self.logger.info(f" tap_states: {self.tap_state}")
+        self.set_braintree_config()
+        end_timestamp = datetime.utcnow().replace(tzinfo=pytz.UTC)
+
+        # Logic for braintree subscriptions full sync.
+        if self.config["sync_state"] == "full":
+            yield from super().get_records(context)
+            return
+
+        start_timestamp = self.get_starting_timestamp(context) or isoparse(self.start_date)
+        start_timestamp = start_timestamp.replace(tzinfo=pytz.UTC)
+
+        yielded_ids = set()
+
+        for start, end in self.date_range(
+            start_timestamp,
+            end_timestamp,
+            interval_in_hours=self.fetch_records_interval_hours,
+        ):
+            # 1. Fetch by Created At (Standard)
+            while True:
+                try:
+                    records = self.braintree_obj.search(
+                        self.braintree_search.between(start, end)
+                    )
+                    self.check_api_result_limits(records)
+                    max_records_expected = records.maximum_size
+                    self.logger.info(
+                        " {}: Fetched {} records from {} - {}".format(
+                            self.name, max_records_expected, start, end
+                        )
+                    )
+
+                    processed_count = 0
+                    for record in records:
+                        if self.contains_latest_record(record, datetime.strptime(self.global_stream_state, "%Y-%m-%d")):
+                            if record.id not in yielded_ids:
+                                yielded_ids.add(record.id)
+                                processed_count += 1
+                                yield self.parse_record(record)
+
+                except braintree.exceptions.down_for_maintenance_error.DownForMaintenanceError as e:
+                    self.logger.error(f" Exception: {str(e)}")
+                    self.logger.error("Waiting 1 hour, then trying again...")
+                    time.sleep(3600)
+                    continue
+
+                except (ConnectionError, Exception) as e: # Catch generic Exception for ReadTimeout which might not be imported
+                    self.logger.error(
+                        " {}: Failed to process records from {} - {}".format(
+                            self.name,
+                            start.date(),
+                            end.date(),
+                        )
+                    )
+                    self.logger.error(f" Exception: {str(e)}")
+                    break
+
+                self.logger.info(
+                    " {}: Processed {} of {} records at {}".format(
+                        self.name,
+                        processed_count,
+                        max_records_expected,
+                        datetime.utcnow(),
+                    )
+                )
+                break
+
+            # 2. Fetch by Transaction Activity (New Logic)
+            self.logger.info(f" {self.name}: Searching for subscriptions via transactions from {start} - {end}")
+            while True:
+                try:
+                    # Search transactions created in this window
+                    transaction_records = braintree.Transaction.search(
+                        braintree.TransactionSearch.created_at.between(start, end)
+                    )
+                    
+                    subscription_ids = set()
+                    for txn in transaction_records:
+                        if hasattr(txn, 'subscription_id') and txn.subscription_id:
+                            subscription_ids.add(txn.subscription_id)
+                    
+                    # Filter out already yielded
+                    subscription_ids = subscription_ids - yielded_ids
+                    
+                    if not subscription_ids:
+                        break
+
+                    self.logger.info(f" {self.name}: Found {len(subscription_ids)} potential updated subscriptions from transactions.")
+
+                    ids_list = list(subscription_ids)
+                    chunk_size = 50
+                    for i in range(0, len(ids_list), chunk_size):
+                        chunk = ids_list[i:i + chunk_size]
+                        
+                        subs = braintree.Subscription.search(
+                            braintree.SubscriptionSearch.ids.in_list(chunk)
+                        )
+                        
+                        for sub in subs:
+                             if self.contains_latest_record(sub, datetime.strptime(self.global_stream_state, "%Y-%m-%d")):
+                                if sub.id not in yielded_ids:
+                                    yielded_ids.add(sub.id)
+                                    yield self.parse_record(sub)
+
+                except braintree.exceptions.down_for_maintenance_error.DownForMaintenanceError as e:
+                    self.logger.error(f" Exception: {str(e)}")
+                    self.logger.error("Waiting 1 hour, then trying again...")
+                    time.sleep(3600)
+                    continue
+                except Exception as e:
+                     self.logger.error(f"Error fetching subscriptions via transactions: {e}")
+                     break
+                
+                break
 
 
 class CustomersStream(BraintreeStream):


### PR DESCRIPTION
# Improve Subscription Sync with Transaction Lookahead

## Problem
The current Braintree API search for subscriptions is limited primarily to `created_at`. This causes issues for our pipeline because:
- We miss updates to older subscriptions (renewals, cancellations, status changes) during daily runs.
- We rely on a heavy "last 3 months" re sync every week to catch these updates, which is inefficient and leaves data gaps during the week.

##  Proposal
This PR introduces a **"Transaction-Based Discovery"** strategy to the `SubscriptionsStream`.

### How it works
1.  **Standard Sync (Unchanged)**:
    - We continue to fetch subscriptions *created* within the target time window. This ensures we capture all new signups.

2.  **Transaction Lookahead (new implementation)**:
    - We now perform an additional search for **Transactions** that occurred within the same time window.
    - We extract the `subscription_id` from every transaction found.
    - We then fetch the latest details for those specific Subscription IDs.

### What would hypoethically happen:
-   **Captures Renewals**: If a user subscribed 6 months ago and their monthly payment processes today, the transaction search will find it, and we will update their subscription record immediately.
-   **Reducing Data Gaps**: We no longer need to wait for the weekly resync to see the latest status of active subscribers.
-   **Efficiency**: We target only the subscriptions that are actually active (transacting), avoiding the need to blindly re-sync large historical datasets.
