### PR TITLE
Add status-based discovery for canceled subscriptions

### DIFF
--- a/tap_braintree/streams.py
+++ b/tap_braintree/streams.py
@@ -1,6 +1,6 @@
 """Stream type classes for tap-braintree."""
 
-from typing import Any, Dict, Optional, Union, List, Iterable
+from typing import Any, Dict, Optional, Union, List, Iterable, Set
 
 from singer_sdk.typing import PropertiesList, Property
 from singer_sdk.typing import (
@@ -579,7 +579,18 @@ class SubscriptionsStream(BraintreeStream):
     ).to_dict()
 
     def get_records(self, context: Optional[dict]) -> Iterable[dict]:
-        """Return a generator of row-type dictionary objects."""
+        """Return a generator of row-type dictionary objects.
+        
+        This method implements a multi-strategy approach to capture subscription updates:
+        
+        1. Created At Search: Captures newly created subscriptions
+        2. Transaction Lookahead: Captures renewals/payments by finding subscriptions 
+           with recent transactions
+        3. Status-Based Discovery: Captures cancellations and status changes by searching
+           for subscriptions in Canceled/Expired states that were recently updated
+        4. Next Billing Date Search: Captures subscriptions with upcoming billing dates
+           to ensure we have their latest state
+        """
         self.logger.info(f" tap_states: {self.tap_state}")
         self.set_braintree_config()
         end_timestamp = datetime.utcnow().replace(tzinfo=pytz.UTC)
@@ -593,13 +604,14 @@ class SubscriptionsStream(BraintreeStream):
         start_timestamp = start_timestamp.replace(tzinfo=pytz.UTC)
 
         yielded_ids = set()
+        last_updated_threshold = datetime.strptime(self.global_stream_state, "%Y-%m-%d")
 
         for start, end in self.date_range(
             start_timestamp,
             end_timestamp,
             interval_in_hours=self.fetch_records_interval_hours,
         ):
-            # 1. Fetch by Created At (Standard)
+            # 1. Fetch by Created At (Standard) - Captures new subscriptions
             while True:
                 try:
                     records = self.braintree_obj.search(
@@ -615,7 +627,7 @@ class SubscriptionsStream(BraintreeStream):
 
                     processed_count = 0
                     for record in records:
-                        if self.contains_latest_record(record, datetime.strptime(self.global_stream_state, "%Y-%m-%d")):
+                        if self.contains_latest_record(record, last_updated_threshold):
                             if record.id not in yielded_ids:
                                 yielded_ids.add(record.id)
                                 processed_count += 1
@@ -627,7 +639,7 @@ class SubscriptionsStream(BraintreeStream):
                     time.sleep(3600)
                     continue
 
-                except (ConnectionError, Exception) as e: # Catch generic Exception for ReadTimeout which might not be imported
+                except (ConnectionError, Exception) as e:
                     self.logger.error(
                         " {}: Failed to process records from {} - {}".format(
                             self.name,
@@ -648,11 +660,10 @@ class SubscriptionsStream(BraintreeStream):
                 )
                 break
 
-            # 2. Fetch by Transaction Activity (New Logic)
+            # 2. Fetch by Transaction Activity - Captures renewals/payments
             self.logger.info(f" {self.name}: Searching for subscriptions via transactions from {start} - {end}")
             while True:
                 try:
-                    # Search transactions created in this window
                     transaction_records = braintree.Transaction.search(
                         braintree.TransactionSearch.created_at.between(start, end)
                     )
@@ -662,28 +673,11 @@ class SubscriptionsStream(BraintreeStream):
                         if hasattr(txn, 'subscription_id') and txn.subscription_id:
                             subscription_ids.add(txn.subscription_id)
                     
-                    # Filter out already yielded
                     subscription_ids = subscription_ids - yielded_ids
                     
-                    if not subscription_ids:
-                        break
-
-                    self.logger.info(f" {self.name}: Found {len(subscription_ids)} potential updated subscriptions from transactions.")
-
-                    ids_list = list(subscription_ids)
-                    chunk_size = 50
-                    for i in range(0, len(ids_list), chunk_size):
-                        chunk = ids_list[i:i + chunk_size]
-                        
-                        subs = braintree.Subscription.search(
-                            braintree.SubscriptionSearch.ids.in_list(chunk)
-                        )
-                        
-                        for sub in subs:
-                             if self.contains_latest_record(sub, datetime.strptime(self.global_stream_state, "%Y-%m-%d")):
-                                if sub.id not in yielded_ids:
-                                    yielded_ids.add(sub.id)
-                                    yield self.parse_record(sub)
+                    if subscription_ids:
+                        self.logger.info(f" {self.name}: Found {len(subscription_ids)} potential updated subscriptions from transactions.")
+                        yield from self._fetch_subscriptions_by_ids(subscription_ids, yielded_ids, last_updated_threshold)
 
                 except braintree.exceptions.down_for_maintenance_error.DownForMaintenanceError as e:
                     self.logger.error(f" Exception: {str(e)}")
@@ -691,10 +685,143 @@ class SubscriptionsStream(BraintreeStream):
                     time.sleep(3600)
                     continue
                 except Exception as e:
-                     self.logger.error(f"Error fetching subscriptions via transactions: {e}")
-                     break
+                    self.logger.error(f"Error fetching subscriptions via transactions: {e}")
+                    break
                 
                 break
+
+        # 3. Status-Based Discovery - Captures cancellations and status changes
+        # Search for subscriptions in terminal states (Canceled, Expired) that may have 
+        # changed status since our last sync. This catches cancellations that don't 
+        # generate transactions.
+        self.logger.info(f" {self.name}: Searching for canceled/expired subscriptions...")
+        yield from self._fetch_subscriptions_by_status(
+            [
+                braintree.Subscription.Status.Canceled,
+                braintree.Subscription.Status.Expired,
+            ],
+            yielded_ids,
+            last_updated_threshold,
+            "canceled/expired"
+        )
+        
+        # Also check PastDue subscriptions - these may transition to canceled
+        self.logger.info(f" {self.name}: Searching for past due subscriptions...")
+        yield from self._fetch_subscriptions_by_status(
+            [braintree.Subscription.Status.PastDue],
+            yielded_ids,
+            last_updated_threshold,
+            "past due"
+        )
+
+        # 4. Next Billing Date Search - Ensures we have fresh data for upcoming renewals
+        # This helps catch any subscriptions that might renew soon and ensures we have
+        # their latest state before the billing happens.
+        upcoming_billing_cutoff = end_timestamp + timedelta(days=7)
+        self.logger.info(f" {self.name}: Searching for subscriptions with upcoming billing dates (next 7 days)...")
+        while True:
+            try:
+                upcoming_subs = braintree.Subscription.search(
+                    braintree.SubscriptionSearch.next_billing_date.between(
+                        end_timestamp, 
+                        upcoming_billing_cutoff
+                    ),
+                    braintree.SubscriptionSearch.status == braintree.Subscription.Status.Active
+                )
+                
+                processed_count = 0
+                for sub in upcoming_subs:
+                    if sub.id not in yielded_ids:
+                        if self.contains_latest_record(sub, last_updated_threshold):
+                            yielded_ids.add(sub.id)
+                            processed_count += 1
+                            yield self.parse_record(sub)
+                
+                self.logger.info(f" {self.name}: Found {processed_count} subscriptions with upcoming billing dates.")
+                
+            except braintree.exceptions.down_for_maintenance_error.DownForMaintenanceError as e:
+                self.logger.error(f" Exception: {str(e)}")
+                self.logger.error("Waiting 1 hour, then trying again...")
+                time.sleep(3600)
+                continue
+            except Exception as e:
+                self.logger.error(f"Error fetching subscriptions by next_billing_date: {e}")
+                break
+            
+            break
+
+        self.logger.info(f" {self.name}: Sync complete. Total unique subscriptions yielded: {len(yielded_ids)}")
+
+    def _fetch_subscriptions_by_ids(
+        self, 
+        subscription_ids: set, 
+        yielded_ids: set, 
+        last_updated_threshold: datetime
+    ) -> Iterable[dict]:
+        """Fetch subscriptions by IDs in chunks and yield parsed records."""
+        ids_list = list(subscription_ids)
+        chunk_size = 50
+        
+        for i in range(0, len(ids_list), chunk_size):
+            chunk = ids_list[i:i + chunk_size]
+            
+            try:
+                subs = braintree.Subscription.search(
+                    braintree.SubscriptionSearch.ids.in_list(chunk)
+                )
+                
+                for sub in subs:
+                    if self.contains_latest_record(sub, last_updated_threshold):
+                        if sub.id not in yielded_ids:
+                            yielded_ids.add(sub.id)
+                            yield self.parse_record(sub)
+                            
+            except Exception as e:
+                self.logger.error(f"Error fetching subscription chunk: {e}")
+                continue
+
+    def _fetch_subscriptions_by_status(
+        self,
+        statuses: List,
+        yielded_ids: set,
+        last_updated_threshold: datetime,
+        status_description: str
+    ) -> Iterable[dict]:
+        """Fetch subscriptions by status and yield those updated since threshold.
+        
+        This is the key method for catching cancellations - subscriptions that 
+        transition to Canceled/Expired don't generate transactions, but their
+        status_history will show they were recently updated.
+        """
+        while True:
+            try:
+                subs = braintree.Subscription.search(
+                    braintree.SubscriptionSearch.status.in_list(statuses)
+                )
+                
+                processed_count = 0
+                for sub in subs:
+                    if sub.id not in yielded_ids:
+                        # Check if this subscription was recently updated
+                        if self.contains_latest_record(sub, last_updated_threshold):
+                            yielded_ids.add(sub.id)
+                            processed_count += 1
+                            yield self.parse_record(sub)
+                
+                self.logger.info(
+                    f" {self.name}: Found {processed_count} recently updated {status_description} subscriptions."
+                )
+                
+            except braintree.exceptions.down_for_maintenance_error.DownForMaintenanceError as e:
+                self.logger.error(f" Exception: {str(e)}")
+                self.logger.error("Waiting 1 hour, then trying again...")
+                time.sleep(3600)
+                continue
+            except Exception as e:
+                self.logger.error(f"Error fetching {status_description} subscriptions: {e}")
+                break
+            
+            break
 
 
 class CustomersStream(BraintreeStream):

--- a/tap_braintree/streams.py
+++ b/tap_braintree/streams.py
@@ -581,7 +581,7 @@ class SubscriptionsStream(BraintreeStream):
     def get_records(self, context: Optional[dict]) -> Iterable[dict]:
         """Return a generator of row-type dictionary objects.
         
-        This method implements a multi-strategy approach to capture subscription updates:
+        Fetches subscription updates using a combination of search strategies:
         
         1. Created At Search: Captures newly created subscriptions
         2. Transaction Lookahead: Captures renewals/payments by finding subscriptions 


### PR DESCRIPTION
The previous implementation only captured subscription updates through:
1. `created_at` searches (new subscriptions)
2. Transaction lookahead (renewals/payments)

This missed canceled subscriptions because cancellations don't generate transactions. They only update the subscription's status.

## Solution:
Added an approach to capture all subscription updates:

| Strategy | What it captures |
|----------|------------------|
| Created At Search | New subscriptions |
| Transaction Lookahead | Renewals, payments |
| **Status-Based Discovery**  | Canceled, Expired, Past Due |
| Next Billing Date Search | Upcoming renewals |

### Changes
- Added `_fetch_subscriptions_by_status()` to search by subscription status
- Added `_fetch_subscriptions_by_ids()` helper for cleaner code
- Searches Canceled, Expired, and PastDue statuses directly from Braintree API
- Added 7-day lookahead for upcoming billing dates